### PR TITLE
Implement resend verification email

### DIFF
--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -16,7 +16,8 @@ export const MESSAGES = {
             PASSWORD_TOO_SHORT: "Password must be at least 8 characters",
             INVALID_VERIFICATION_TOKEN: "Invalid or expired verification token.",
             SEND_FAILED: 'Failed to send email. Please try again later.',
-            EMAIL_NOT_VERIFIED: 'You must verify your email before logging in.'
+            EMAIL_NOT_VERIFIED: 'You must verify your email before logging in.',
+            ALREADY_VERIFIED: 'This email is already verified.',
         },
         AUTHORIZATION: {
             FORBIDDEN: 'You do not have permission to access this resource.',
@@ -48,7 +49,8 @@ export const MESSAGES = {
         },
         AUTH: {
             PASSWORD_UPDATED: "Password updated successfully",
-            EMAIL_VERIFIED: "Email successfully verified."
+            EMAIL_VERIFIED: "Email successfully verified.",
+            VERIFICATION_EMAIL_RESENT: 'Verification email resent successfully.',
         }
     },
 };

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -140,3 +140,17 @@ export const verifyEmail = async (req: Request, res: Response, next: NextFunctio
         next(error);
     }
 };
+
+export const resendVerificationEmail = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const { email } = req.body;
+
+        await userService.resendVerificationEmail(email);
+
+        res.status(200).json({
+            message: MESSAGES.SUCCESS.AUTH.VERIFICATION_EMAIL_RESENT
+        });
+    } catch (error) {
+        next(error);
+    }
+};

--- a/src/dtos/resendVerificationEmail.dto.ts
+++ b/src/dtos/resendVerificationEmail.dto.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+import { MESSAGES } from '../constants/messages';
+
+export const ResendVerificationEmailSchema = z.object({
+    email: z.string({ required_error: MESSAGES.VALIDATION.USER.EMAIL_REQUIRED }).email(MESSAGES.VALIDATION.USER.INVALID_EMAIL),
+});
+
+export type ResendVerificationEmailDto = z.infer<typeof ResendVerificationEmailSchema>;

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -4,12 +4,14 @@ import {
     login,
     logout,
     refreshAccessToken,
+    resendVerificationEmail,
     verifyEmail,
 } from "../controllers/auth.controller";
 import { validateZod } from "../middlewares/validateZod";
 import { loginSchema } from "../validations/auth.schema";
 import { authMiddleware } from "../middlewares/auth.middleware";
 import { changePasswordSchema } from "../validations/changePassword.schema";
+import { ResendVerificationEmailSchema } from "../dtos/resendVerificationEmail.dto";
 
 const router = express.Router();
 
@@ -18,5 +20,6 @@ router.post("/change-password", authMiddleware, validateZod(changePasswordSchema
 router.post("/logout", authMiddleware, logout);
 router.post("/refresh-token", refreshAccessToken);
 router.get('/verify-email/:token', verifyEmail);
+router.post('/resend-verification', validateZod(ResendVerificationEmailSchema), resendVerificationEmail);
 
 export default router;  

--- a/src/utils/email.util.ts
+++ b/src/utils/email.util.ts
@@ -1,10 +1,10 @@
 import { mailer } from "../lib/mailer";
+import { generateVerificationEmailHTML } from "./emailTemplates/verificationEmail";
 
 
 export async function sendEmailVerification(email: string, token: string) {
-    const verificationUrl = `${process.env.FRONTEND_URL}/api/auth/verify-email/${token}`;
-    const subject = 'Verify your email';
-    const html = `<p>Click <a href="${verificationUrl}">here</a> to verify your email.</p>`;
+
+    const { subject, html } = generateVerificationEmailHTML(token)
 
     // Reutilizá tu sistema de mailing
     await mailer.sendMail(email, subject, html);

--- a/src/utils/emailTemplates/verificationEmail.ts
+++ b/src/utils/emailTemplates/verificationEmail.ts
@@ -1,0 +1,24 @@
+export function generateVerificationEmailHTML(token: string): { subject: string; html: string } {
+    const verificationUrl = `${process.env.FRONTEND_URL}/api/auth/verify-email/${token}`;
+    const subject = 'Verificá tu dirección de correo';
+
+    const html = `
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #f9f9f9;">
+        <h2 style="color: #333;">Confirmá tu dirección de correo</h2>
+        <p style="font-size: 16px; color: #555;">
+          Gracias por registrarte. Por favor, confirmá tu dirección de correo electrónico haciendo clic en el siguiente botón:
+        </p>
+        <div style="text-align: center; margin: 30px 0;">
+          <a href="${verificationUrl}" 
+             style="background-color: #4CAF50; color: white; padding: 12px 24px; text-decoration: none; border-radius: 5px; font-size: 16px;">
+            Verificar correo
+          </a>
+        </div>
+        <p style="font-size: 14px; color: #888;">
+          Si vos no creaste esta cuenta, podés ignorar este mensaje.
+        </p>
+      </div>
+    `;
+
+    return { subject, html };
+}


### PR DESCRIPTION
### Resumen
Implementa el reenvío de verificación de email para usuarios que aún no confirmaron su cuenta.

### Cambios
- Nuevo endpoint: POST /api/auth/resend-verification
- Validación de email ya verificado
- Reutiliza lógica de nodemailer

### Testeado
✅ Endpoint probado con Postman  
✅ Emails enviados correctamente  